### PR TITLE
V1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,18 @@
-FROM fluent/fluentd:v0.14-debian
-MAINTAINER Joakim Karlsson <joakim@roffe.nu>
+FROM debian:stretch-slim
+LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV DUMB_INIT_SETSID 0
+ENV DUMB_INIT_VERSION=1.2.0
+
+ENV FLUENTD_CONF="fluent.conf"
+ENV FLUENTD_OPT=""
+
+ENV GOSU_VERSION=1.10
+
+RUN mkdir -p /fluentd/etc /fluentd/plugins /fluentd/log
 
 RUN apt-get update \
  && apt-get upgrade -y \
@@ -14,16 +27,37 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && update-ca-certificates \
  && echo 'gem: --no-document' >> /etc/gemrc \
- && gem install fluent-plugin-kubernetes_metadata_filter_v0.14 -v 0.24.1 \
- && gem install gelf -v 3.0.0 \
- && gem install fluent-plugin-systemd -v 0.3.0 \
+ && gem install oj -v 2.18.3 \
+ && gem install json -v 2.1.0 \
+ && gem install fluentd -v 1.0.2 \
+ && gem install fluent-plugin-kubernetes_metadata_filter -v 1.0.0 \
+ && gem install fluent-plugin-systemd -v 0.3.1 \
  && wget https://raw.githubusercontent.com/bedag/fluent-plugin-gelf/master/lib/fluent/plugin/out_gelf.rb -O /fluentd/plugins/out_gelf.rb \
+ && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+ && wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_$dpkgArch \
+ && chmod +x /usr/bin/dumb-init \
+ && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
+ && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
+ && export GNUPGHOME="$(mktemp -d)" \
+ && gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+ && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+ && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+ && chmod +x /usr/local/bin/gosu \
+ && gosu nobody true \
+ && wget -O /tmp/jemalloc-4.4.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.4.0/jemalloc-4.4.0.tar.bz2 \
+ && cd /tmp && tar -xjf jemalloc-4.4.0.tar.bz2 && cd jemalloc-4.4.0/ \
+ && ./configure && make \
+ && mv lib/libjemalloc.so.2 /usr/lib \
  && apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \
                   $buildDeps \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 
-ENTRYPOINT ["gosu"]
+ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
 
-CMD ["root", "fluentd", "-c", "/fluentd/etc/fluent.conf", "-p", "/fluentd/plugins"]
+# EXPOSE 24224 5140
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+CMD fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch-slim
-LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
+LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com> , Tweaked by Joakim Karlsson <joakim@roffe.nu>"
+LABEL Description="Fluentd docker image" Vendor="roffe.nu" Version="1.1"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -9,8 +9,6 @@ ENV DUMB_INIT_VERSION=1.2.0
 
 ENV FLUENTD_CONF="fluent.conf"
 ENV FLUENTD_OPT=""
-
-ENV GOSU_VERSION=1.10
 
 RUN mkdir -p /fluentd/etc /fluentd/plugins /fluentd/log
 
@@ -32,18 +30,10 @@ RUN apt-get update \
  && gem install fluentd -v 1.0.2 \
  && gem install fluent-plugin-kubernetes_metadata_filter -v 1.0.0 \
  && gem install fluent-plugin-systemd -v 0.3.1 \
- && wget https://raw.githubusercontent.com/bedag/fluent-plugin-gelf/master/lib/fluent/plugin/out_gelf.rb -O /fluentd/plugins/out_gelf.rb \
- && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+ && gem install fluent-plugin-graylog -v 1.0.2 \
+  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_$dpkgArch \
  && chmod +x /usr/bin/dumb-init \
- && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
- && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
- && export GNUPGHOME="$(mktemp -d)" \
- && gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
- && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
- && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
- && chmod +x /usr/local/bin/gosu \
- && gosu nobody true \
  && wget -O /tmp/jemalloc-4.4.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.4.0/jemalloc-4.4.0.tar.bz2 \
  && cd /tmp && tar -xjf jemalloc-4.4.0.tar.bz2 && cd jemalloc-4.4.0/ \
  && ./configure && make \

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ for POD in `kubectl get pod --namespace kube-system -l app=kube-gelf | tail -n +
 ```
 
 ## Cron
+
 As of Kubernetes 1.8 batch/v1beta1 is enabled by default and no additional changes are needed.
 
 If you are on < 1.8:
@@ -36,16 +37,17 @@ Also change the apiVersion from batch/v1beta1 to batch/v2alpha1
 The cron.yaml can be used to deploy a cronJob that periodicly tells kube-gelf to reload it's configuration to also works around some fluend bugs.
 
 ## Fluentd Bugs
+
 in_tail prevents docker from removing container
-https://github.com/fluent/fluentd/issues/1680
+<https://github.com/fluent/fluentd/issues/1680>.
 
 in_tail removes untracked file position during startup phase. It means the content of pos_file is growing until restart when you tails lots of files with dynamic path setting. I will fix this problem in the future. Check this issue.
-https://github.com/fluent/fluentd/issues/1126
-
+<https://github.com/fluent/fluentd/issues/1126>.
 
 ## Changelog
 
 ### 1.1
-Got rid of hostNetwork and added a NODENAME env variable utilizing the downward api.
 
-Changed output filter to the official graylog output. this required a change in the config file so please update your configmap.
+Got rid of hostNetwork and added a NODENAME env variable utilizing the downward api. All log entries will contain the field `hostname: <your nodename in kubernetes>`
+
+Changed output filter to the gem fluent-plugin-graylog 1.0.2, this required a change in the config file so please update your configmap.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ https://github.com/fluent/fluentd/issues/1680
 
 in_tail removes untracked file position during startup phase. It means the content of pos_file is growing until restart when you tails lots of files with dynamic path setting. I will fix this problem in the future. Check this issue.
 https://github.com/fluent/fluentd/issues/1126
+
+
+## Changelog
+
+### 1.1
+Got rid of hostNetwork and added a NODENAME env variable utilizing the downward api.
+
+Changed output filter to the official graylog output. this required a change in the config file so please update your configmap.

--- a/cron.yaml
+++ b/cron.yaml
@@ -14,7 +14,7 @@ spec:
           serviceAccountName: kube-gelf
           containers:
           - name: cron
-            image: roffe/kubectl:1.8.3
+            image: roffe/kubectl:v1.9.0
             args:
             - /bin/sh
             - -c

--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-gelf
@@ -17,11 +17,10 @@ spec:
         app: kube-gelf
     spec:
       serviceAccountName: kube-gelf
-      # To get host nodename, needs to be solved more elegant
-      hostNetwork: true
+      dnsPolicy: ClusterFirst
       containers:
       - name: agent
-        image: roffe/kube-gelf:latest
+        image: roffe/kube-gelf:v1.1
         env:
         - name: GELF_HOST
           valueFrom:

--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -32,6 +32,10 @@ spec:
             configMapKeyRef:
               name: kube-gelf
               key: GELF_PORT
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/fluent.conf
+++ b/fluent.conf
@@ -36,14 +36,23 @@
   bearer_token_file /var/run/secrets/kubernetes.io/serviceaccount/token
 </filter>
 
+<filter access>
+  @type record_transformer
+  <record>
+    hostname "#{ENV['NODENAME']}"
+  </record>
+</filter>
+
+
 <match **>
    @type copy
    <store>
-     @type gelf
+     @type graylog
      include_tag_key true
      host "#{ENV['GELF_HOST']}"
      port "#{ENV['GELF_PORT']}"
-     flush_interval 5s
+     flush_interval 10s
+     num_threads 2
      use_record_host true
      buffer_chunk_limit 4096K
      buffer_queue_limit 512


### PR DESCRIPTION
Got rid of hostNetwork and replaced it with a ENV variable NODENAME propagated by spec.nodeName from the downward api.

Updated fluentd to the latest version and used the graylog output filter from gem.