### PR TITLE
update daemonset for using latest image

### DIFF
--- a/daemonset.yaml
+++ b/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
       - name: agent
-        image: roffe/kube-gelf:v1.2.1
+        image: roffe/kube-gelf:latest
         env:
         - name: GELF_HOST
           valueFrom:


### PR DESCRIPTION
This is a simple PR but if we use v1.2.1, the daemonset crashes because of the plugin install. 
The image placed in daemonset should be replaced to latest.