### PR TITLE
Buffer configuration in fluentd 1.0 format

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -64,12 +64,17 @@
      # 'cert' [String, IO] the client certificate file
      # 'key' [String, IO] the key for the client certificate
      # 'all_ciphers' [Boolean] allows any ciphers to be used, may be insecure
-     flush_interval 10s
-     num_threads 2
+     <buffer>
+       flush_at_shutdown true
+       flush_mode immediate
+       flush_thread_count 4
+       flush_thread_interval 1
+       flush_thread_burst_interval 1
+       retry_forever false
+       retry_max_times 3
+       retry_type exponential_backoff
+     </buffer>
      use_record_host true
-     buffer_chunk_limit 4096K
-     buffer_queue_limit 512
-     max_retry_wait 300
    </store>
 </match>
 


### PR DESCRIPTION
The Docker image is built with fluentd 1.0, but the config file is still in the old 0.12 format.
Adjusted the buffer configuration to be now compatible with https://docs.fluentd.org/configuration/buffer-section